### PR TITLE
App argument 'option' to destroyCookie()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+NOTE: This repository was forked to fix a bug. We hope to get the bug upstream and remove the repository.
+
 # nookies :cookie: :cookie: :cookie:
 
 [![CircleCI](https://circleci.com/gh/maticzav/nookies/tree/master.svg?style=shield)](https://circleci.com/gh/maticzav/nookies/tree/master) [![npm version](https://badge.fury.io/js/nookies.svg)](https://badge.fury.io/js/nookies)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-NOTE: This repository was forked to fix a bug. We hope to get the bug upstream and remove the repository.
-
 # nookies :cookie: :cookie: :cookie:
 
 [![CircleCI](https://circleci.com/gh/maticzav/nookies/tree/master.svg?style=shield)](https://circleci.com/gh/maticzav/nookies/tree/master) [![npm version](https://badge.fury.io/js/nookies.svg)](https://badge.fury.io/js/nookies)

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export function setCookie(ctx = {}, name, value, options = {}) {
   return {}
 }
 
-export function destroyCookie(ctx = {}, name) {
+export function destroyCookie(ctx = {}, name, options = {}) {
   if (ctx && ctx.res) {
     let cookies = ctx.res.getHeader('set-cookie') || []
 
@@ -44,6 +44,7 @@ export function destroyCookie(ctx = {}, name) {
     cookies.push(
       cookie.serialize(name, '', {
         maxAge: -1,
+        options,
       }),
     )
 
@@ -53,6 +54,7 @@ export function destroyCookie(ctx = {}, name) {
   if (process.browser) {
     document.cookie = cookie.serialize(name, '', {
       maxAge: -1,
+      options,
     })
   }
 


### PR DESCRIPTION
Right now it's not possible to destroy a cookie which was created on a path not equal the current one.