### PR TITLE
fix: make ctx optional to allow omit on client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function parseCookies(
   options?: cookie.CookieParseOptions,
 ) {
   if (ctx && ctx.req && ctx.req.headers.cookie) {
-    return cookie.parse(ctx.req.headers.cookie as string, options)
+    return cookie.parse(ctx.req.headers.cookie, options)
   }
 
   if (isBrowser()) {
@@ -128,7 +128,7 @@ export function setCookie(
  * @param options
  */
 export function destroyCookie(
-  ctx: next.NextContext,
+  ctx: next.NextContext | null | undefined,
   name: string,
   options: cookie.CookieSerializeOptions,
 ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ function createCookie(
  * @param options
  */
 export function parseCookies(
-  ctx: next.NextContext,
+  ctx?: next.NextContext | null | undefined,
   options?: cookie.CookieParseOptions,
 ) {
   if (ctx && ctx.req && ctx.req.headers.cookie) {
@@ -79,7 +79,7 @@ export function parseCookies(
  * @param options
  */
 export function setCookie(
-  ctx: next.NextContext,
+  ctx: next.NextContext | null | undefined,
   name: string,
   value: string,
   options: cookie.CookieSerializeOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function parseCookies(
   options?: cookie.CookieParseOptions,
 ) {
   if (ctx && ctx.req && ctx.req.headers.cookie) {
-    return cookie.parse(ctx.req.headers.cookie, options)
+    return cookie.parse(ctx.req.headers.cookie as string, options)
   }
 
   if (isBrowser()) {


### PR DESCRIPTION
fix #61 

Typescript throws an error when you try to omit the ctx on client:

```ts
// Simply omit context parameter.
const cookies = parseCookies()
```

```
Expected 1-2 arguments, but got 0.ts(2554)
index.d.ts(10, 38): An argument for 'ctx' was not provided.
```

I added `null | undefined` to allow setting second parameter of `parseCookies` and `setCookie` on client.