### PR TITLE
feat: narrow the argument types for setCookie and parseCookies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ function createCookie(
  * @param options
  */
 export function parseCookies(
-  ctx?: next.NextPageContext | null | undefined,
+  ctx?: Pick<next.NextPageContext, 'req'> | null | undefined,
   options?: cookie.CookieParseOptions,
 ) {
   if (ctx && ctx.req && ctx.req.headers && ctx.req.headers.cookie) {
@@ -104,7 +104,7 @@ export function parseCookies(
  * @param options
  */
 export function setCookie(
-  ctx: next.NextPageContext | null | undefined,
+  ctx: Pick<next.NextPageContext, 'res'> | null | undefined,
   name: string,
   value: string,
   options: cookie.CookieSerializeOptions,


### PR DESCRIPTION
I narrowed the types for `ctx` argument of `parseCookies` and `setCookie` to the only property that is used. It allows to use the functions with other compatible objects and inside API routes.