### PR TITLE
Replace jsmin with terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "compile": "tsc -d && yarn run minify",
-    "minify": "jsmin -o dist/index.min.js dist/index.js",
+    "minify": "terser -c -m --source-map \"content='./dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js -- dist/index.js",
     "pretest": "npm run clean && npm run compile",
     "test": "echo 'test'",
     "posttest": "npm run lint",
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "cookie": "^0.4.0",
-    "jsmin": "^1.0.1",
     "set-cookie-parser": "^2.4.3"
   },
   "devDependencies": {
@@ -38,6 +37,7 @@
     "pretty-quick": "2.0.1",
     "rimraf": "3.0.2",
     "semantic-release": "17.0.7",
+    "terser": "^4.6.12",
     "ts-loader": "6.2.2",
     "ts-node": "8.9.1",
     "tslint": "6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5178,11 +5178,6 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-jsmin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jsmin/-/jsmin-1.0.1.tgz#e7bd0dcd6496c3bf4863235bf461a3d98aa3b98c"
-  integrity sha1-570NzWSWw79IYyNb9GGj2YqjuYw=
-
 json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -9412,6 +9407,15 @@ terser@^4.1.2:
   version "4.6.6"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.6.tgz#da2382e6cafbdf86205e82fb9a115bd664d54863"
   integrity sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
+terser@^4.6.12:
+  version "4.6.12"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.12.tgz#44b98aef8703fdb09a3491bf79b43faffc5b4fee"
+  integrity sha512-fnIwuaKjFPANG6MAixC/k1TDtnl1YlPLUlLVIxxGZUn1gfUx2+l3/zGNB72wya+lgsb50QBi2tUV75RiODwnww==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
Hi,

This PR replaces [jsmin](https://github.com/pkrumins/node-jsmin) with [terser](https://github.com/terser/terser).

JSMin hasn't been updated for 8 years and doesn't use a standard license.
Terser has become the de-facto minifier for JS/ES and also generates a smaller output while still supporting sourcemaps (even composed).

I also took the liberty of moving the minifier dependency from a dependency to a dev dependency, seeing as it's only needed at build/publish time.

Fixes #252