### PR TITLE
refactor: change multiple props check to Optional chaining Operator [ enhance readability ]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export function parseCookies(
     | undefined,
   options?: cookie.CookieParseOptions,
 ) {
-  if (ctx && ctx.req && ctx.req.headers && ctx.req.headers.cookie) {
+  if (ctx?.req?.headers?.cookie) {
     return cookie.parse(ctx.req.headers.cookie as string, options)
   }
 
@@ -120,7 +120,7 @@ export function setCookie(
   value: string,
   options: cookie.CookieSerializeOptions,
 ) {
-  if (ctx && ctx.res && ctx.res.getHeader && ctx.res.setHeader) {
+  if (ctx?.res?.getHeader && ctx.res.setHeader) {
     let cookies = ctx.res.getHeader('Set-Cookie') || []
 
     if (typeof cookies === 'string') cookies = [cookies]
@@ -177,7 +177,7 @@ export function destroyCookie(
 ) {
   const opts = { ...(options || {}), maxAge: -1 }
 
-  if (ctx && ctx.res && ctx.res.setHeader && ctx.res.getHeader) {
+  if (ctx?.res?.setHeader && ctx.res.getHeader) {
     let cookies = ctx.res.getHeader('Set-Cookie') || []
 
     if (typeof cookies === 'string') cookies = [cookies]


### PR DESCRIPTION

###  Refactor code to use Optional Chaining Operator [ TypeScript ] 
- yarn run prettier : Done 👍🏼 
- yarn run compile : Pass ✅ 

The Build is slightly different but it's exactly the same behavior

Example : 
```
(((_a = ctx === null || ctx === void 0 ? void 0 : ctx.res) === null || _a === void 0 ? void 0 : _a.getHeader) && ctx.res.setHeader) 
```