### PR TITLE
fix: update GitHub Actions runner to ubuntu-latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION

Origin: on this PR, there's was a merge https://github.com/maticzav/nookies/pull/584#event-15714110638 and the action failed to published the package at https://github.com/maticzav/nookies/actions/runs/12409459594/job/34643124470 

With the errors:
> 🚫 This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.
> ⚠️ The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

This PR fixes it by using a ubuntu-latest, which will always pick ubuntu latest LST version, preventing picking deprecated ubuntu versions in the future.

